### PR TITLE
Move useNativeAsObject config to OpenRtbJsonFactory.

### DIFF
--- a/openrtb-core/src/main/java/com/google/openrtb/json/AbstractOpenRtbJsonReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/AbstractOpenRtbJsonReader.java
@@ -38,19 +38,9 @@ import java.util.Set;
 public abstract class AbstractOpenRtbJsonReader {
   static final Logger logger = LoggerFactory.getLogger(AbstractOpenRtbJsonReader.class);
   private final OpenRtbJsonFactory factory;
-  private final boolean useNativeAsObject;
 
   protected AbstractOpenRtbJsonReader(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected AbstractOpenRtbJsonReader(OpenRtbJsonFactory factory, boolean isNativeAsObject) {
     this.factory = factory;
-    this.useNativeAsObject = isNativeAsObject;
-  }
-
-  public final boolean useNativeAsObject() {
-    return useNativeAsObject;
   }
 
   public final OpenRtbJsonFactory factory() {

--- a/openrtb-core/src/main/java/com/google/openrtb/json/AbstractOpenRtbJsonWriter.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/AbstractOpenRtbJsonWriter.java
@@ -31,23 +31,13 @@ import java.util.Map;
  */
 public class AbstractOpenRtbJsonWriter {
   private final OpenRtbJsonFactory factory;
-  private final boolean useNativeAsObject;
 
   protected AbstractOpenRtbJsonWriter(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected AbstractOpenRtbJsonWriter(OpenRtbJsonFactory factory, boolean isNativeAsObject) {
     this.factory = factory;
-    this.useNativeAsObject = isNativeAsObject;
   }
 
   public final OpenRtbJsonFactory factory() {
     return factory;
-  }
-
-  public final boolean useNativeAsObject() {
-    return useNativeAsObject;
   }
 
   /**

--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
@@ -87,11 +87,7 @@ import java.io.Reader;
 public class OpenRtbJsonReader extends AbstractOpenRtbJsonReader {
 
   protected OpenRtbJsonReader(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected OpenRtbJsonReader(OpenRtbJsonFactory factory, final boolean isNativeAsObject) {
-    super(factory, isNativeAsObject);
+    super(factory);
   }
 
   /**
@@ -312,7 +308,7 @@ public class OpenRtbJsonReader extends AbstractOpenRtbJsonReader {
       throws IOException {
     switch (fieldName) {
       case "request": {
-          if (useNativeAsObject()) {
+          if (factory().useNativeAsObject()) {
             readNativeAsObject(nativ, par);
           } else {
             readNativeAsString(nativ, par);
@@ -350,7 +346,7 @@ public class OpenRtbJsonReader extends AbstractOpenRtbJsonReader {
   }
 
   private void readNativeAsObject(Native.Builder aNative, JsonParser aPar) throws IOException {
-    OpenRtbNativeJsonReader nativeObjectReader = factory().newNativeReader(true);
+    OpenRtbNativeJsonReader nativeObjectReader = factory().newNativeReader();
     aNative.setRequestNative(nativeObjectReader.readNativeRequest(aPar));
   }
 

--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonWriter.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonWriter.java
@@ -16,8 +16,10 @@
 
 package com.google.openrtb.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
+import static com.google.openrtb.json.OpenRtbJsonUtils.writeEnums;
+import static com.google.openrtb.json.OpenRtbJsonUtils.writeIntBoolField;
+import static com.google.openrtb.json.OpenRtbJsonUtils.writeStrings;
+
 import com.google.openrtb.OpenRtb.BidRequest;
 import com.google.openrtb.OpenRtb.BidRequest.App;
 import com.google.openrtb.OpenRtb.BidRequest.Content;
@@ -42,12 +44,13 @@ import com.google.openrtb.OpenRtb.BidResponse.SeatBid;
 import com.google.openrtb.OpenRtb.BidResponse.SeatBid.Bid;
 import com.google.openrtb.util.OpenRtbUtils;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
-
-import static com.google.openrtb.json.OpenRtbJsonUtils.*;
 
 /**
  * Serializes OpenRTB {@link BidRequest}/{@link BidResponse} messages to JSON.
@@ -61,11 +64,7 @@ public class OpenRtbJsonWriter extends AbstractOpenRtbJsonWriter {
   private OpenRtbNativeJsonWriter nativeWriter;
 
   protected OpenRtbJsonWriter(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected OpenRtbJsonWriter(OpenRtbJsonFactory factory, final boolean isNativeAsObject) {
-    super(factory, isNativeAsObject);
+    super(factory);
   }
 
   /**
@@ -372,9 +371,9 @@ public class OpenRtbJsonWriter extends AbstractOpenRtbJsonWriter {
 
   private void writeNativeObject(final Native aNativ, final JsonGenerator aGen) throws IOException
   {
-    if(useNativeAsObject()) {
+    if(factory().useNativeAsObject()) {
       aGen.writeFieldName("request");
-      new OpenRtbNativeJsonWriter(factory(), true).writeNativeRequest(aNativ.getRequestNative(), aGen);
+      nativeWriter().writeNativeRequest(aNativ.getRequestNative(), aGen);
     }
     else {
       aGen.writeStringField("request", nativeWriter().writeNativeRequest(aNativ.getRequestNative()));
@@ -997,8 +996,8 @@ public class OpenRtbJsonWriter extends AbstractOpenRtbJsonWriter {
 
   private void writeAdmNative(final Bid aBid, final JsonGenerator aGen) throws IOException
   {
-    if(useNativeAsObject()) {
-      new OpenRtbNativeJsonWriter(factory(), true).writeNativeResponse(aBid.getAdmNative(), aGen);
+    if(factory().useNativeAsObject()) {
+      nativeWriter().writeNativeResponse(aBid.getAdmNative(), aGen);
     }
     else {
       aGen.writeStringField("adm", nativeWriter().writeNativeResponse(aBid.getAdmNative()));
@@ -1008,8 +1007,8 @@ public class OpenRtbJsonWriter extends AbstractOpenRtbJsonWriter {
   private void writeAdmObj(final Bid aBid, final JsonGenerator aGen) throws IOException
   {
     aGen.writeFieldName("adm");
-    if(useNativeAsObject()) {
-      new OpenRtbJsonWriter(factory(), true).writeAdmNative(aBid, aGen);
+    if(factory().useNativeAsObject()) {
+      new OpenRtbJsonWriter(factory()).writeAdmNative(aBid, aGen);
     }
     else {
       aGen.writeString(aBid.getAdm());

--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbNativeJsonReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbNativeJsonReader.java
@@ -50,11 +50,7 @@ public class OpenRtbNativeJsonReader extends AbstractOpenRtbJsonReader {
   private OpenRtbJsonReader coreReader;
 
   protected OpenRtbNativeJsonReader(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected OpenRtbNativeJsonReader(OpenRtbJsonFactory factory, boolean isNativeAsObject) {
-    super(factory, isNativeAsObject);
+    super(factory);
   }
 
   /**

--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbNativeJsonWriter.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbNativeJsonWriter.java
@@ -42,11 +42,7 @@ public class OpenRtbNativeJsonWriter extends AbstractOpenRtbJsonWriter {
   private OpenRtbJsonWriter coreWriter;
 
   protected OpenRtbNativeJsonWriter(OpenRtbJsonFactory factory) {
-    this(factory, false);
-  }
-
-  protected OpenRtbNativeJsonWriter(OpenRtbJsonFactory factory, boolean isNativeAsObject) {
-    super(factory, isNativeAsObject);
+    super(factory);
   }
 
   /**

--- a/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbExtJsonTest.java
+++ b/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbExtJsonTest.java
@@ -50,12 +50,13 @@ public class OpenRtbExtJsonTest {
 
   static class MyOpenRtbJsonFactory extends OpenRtbJsonFactory {
     protected MyOpenRtbJsonFactory(
-        @Nullable JsonFactory jsonFactory,
-        boolean strict,
-        boolean rootNativeField,
-        @Nullable SetMultimap<String, OpenRtbJsonExtReader<?>> extReaders,
-        @Nullable Map<String, Map<String, Map<String, OpenRtbJsonExtWriter<?>>>> extWriters) {
-      super(jsonFactory, strict, rootNativeField, extReaders, extWriters);
+       @Nullable JsonFactory jsonFactory,
+       boolean strict,
+       boolean rootNativeField,
+       boolean useNativeAsObject,
+       @Nullable SetMultimap<String, OpenRtbJsonExtReader<?>> extReaders,
+       @Nullable Map<String, Map<String, Map<String, OpenRtbJsonExtWriter<?>>>> extWriters) {
+      super(jsonFactory, strict, rootNativeField, useNativeAsObject, extReaders, extWriters);
     }
 
     protected MyOpenRtbJsonFactory(MyOpenRtbJsonFactory config) {
@@ -63,9 +64,9 @@ public class OpenRtbExtJsonTest {
     }
 
     public static MyOpenRtbJsonFactory create() {
-      return new MyOpenRtbJsonFactory(null, false, true, null, null);
+      return new MyOpenRtbJsonFactory(null, false, true, false, null, null);
     }
-
+    
     @Override public OpenRtbJsonReader newReader() {
       return new MyOpenRtbJsonReader(new MyOpenRtbJsonFactory(this));
     }

--- a/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbJsonTest.java
+++ b/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbJsonTest.java
@@ -407,17 +407,17 @@ public class OpenRtbJsonTest {
             "{\"id\":4,\"required\":0,\"data\":{\"type\":12,\"len\":25}}," +
             "{\"id\":5}]}}}],\"app\":{},\"device\":{},\"user\":{},\"regs\":{}}";
 
-    String jsonReq = jsonFactory.newWriter(false).writeBidRequest(req);
+    String jsonReq = jsonFactory.setUseNativeAsObject(false).newWriter().writeBidRequest(req);
     assertThat(jsonReq).isEqualTo(compareReqNativeAsStr);
-    jsonFactory.setStrict(false).newWriter(false).writeBidRequest(req);
+    jsonFactory.setStrict(false).setUseNativeAsObject(false).newWriter().writeBidRequest(req);
 
-    BidRequest req2 = jsonFactory.newReader(false).readBidRequest(jsonReq);
-    String jsonReq2 = jsonFactory.newWriter(true).writeBidRequest(req2);
+    BidRequest req2 = jsonFactory.setUseNativeAsObject(false).newReader().readBidRequest(jsonReq);
+    String jsonReq2 = jsonFactory.setUseNativeAsObject(true).newWriter().writeBidRequest(req2);
     assertThat(jsonReq2).isEqualTo(compareReqNativeAsObj);
     assertThat(req2).isEqualTo(req);
 
-    BidRequest req3 = jsonFactory.setStrict(false).newReader(true).readBidRequest(jsonReq2);
-    String jsonReq3 = jsonFactory.newWriter(true).writeBidRequest(req3);
+    BidRequest req3 = jsonFactory.setStrict(false).setUseNativeAsObject(true).newReader().readBidRequest(jsonReq2);
+    String jsonReq3 = jsonFactory.setUseNativeAsObject(true).newWriter().writeBidRequest(req3);
     assertThat(jsonReq3).isEqualTo(compareReqNativeAsObj);
     assertThat(req3).isEqualTo(req);
   }
@@ -464,7 +464,7 @@ public class OpenRtbJsonTest {
     assertThat(jsonRespNativeStr).isEqualTo(compareRespNativeAsStr);
 
     OpenRtb.BidResponse resp2 = jsonFactory.newReader().readBidResponse(jsonRespNativeStr);
-    String jsonRespNativeObj = jsonFactory.newWriter(true).writeBidResponse(resp2);
+    String jsonRespNativeObj = jsonFactory.setUseNativeAsObject(true).newWriter().writeBidResponse(resp2);
 
 //    OpenRtb.BidResponse resp3 = jsonFactory.newReader(true).readBidResponse(jsonRespNativeObj);
 //    jsonRespNativeObj = jsonFactory.newWriter(true).writeBidResponse(resp3);

--- a/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbNativeJsonTest.java
+++ b/openrtb-core/src/test/java/com/google/openrtb/json/OpenRtbNativeJsonTest.java
@@ -138,21 +138,21 @@ public class OpenRtbNativeJsonTest {
   }
 
   static void testRequestWithNativeAsObject(OpenRtbJsonFactory jsonFactory, NativeRequest req) throws IOException {
-    String jsonReq = jsonFactory.newNativeWriter(true).writeNativeRequest(req);
+    String jsonReq = jsonFactory.setUseNativeAsObject(true).newNativeWriter().writeNativeRequest(req);
     logger.error(jsonReq);
     NativeRequest req2 = jsonFactory.newNativeReader().readNativeRequest(jsonReq);
     assertThat(req2).isEqualTo(req);
   }
 
   static void testResponseWithNativeAsString(OpenRtbJsonFactory jsonFactory, NativeResponse resp) throws IOException {
-    String jsonResp = jsonFactory.newNativeWriter(false).writeNativeResponse(resp);
+    String jsonResp = jsonFactory.setUseNativeAsObject(false).newNativeWriter().writeNativeResponse(resp);
     logger.error(jsonResp);
     NativeResponse resp2 = jsonFactory.newNativeReader().readNativeResponse(jsonResp);
     assertThat(resp2).isEqualTo(resp);
   }
 
   static void testResponseWithNativeAsObject(OpenRtbJsonFactory jsonFactory, NativeResponse resp) throws IOException {
-    String jsonResp = jsonFactory.newNativeWriter(true).writeNativeResponse(resp);
+    String jsonResp = jsonFactory.setUseNativeAsObject(true).newNativeWriter().writeNativeResponse(resp);
     logger.error(jsonResp);
     NativeResponse resp2 = jsonFactory.newNativeReader().readNativeResponse(jsonResp);
     assertThat(resp2).isEqualTo(resp);


### PR DESCRIPTION
So kann `useNativeAsObject` genau wie `strict` und `rootNativeField` an der Factory konfiguriert werden. Das macht die Benutzung einheitlicher und der Diff zum Original wird auch kleiner.
